### PR TITLE
doc: Fix incorrect `Sphinx_EXECUTABLE` variable name

### DIFF
--- a/cmake/CMakeshift/InstallBasicPackageFiles.cmake
+++ b/cmake/CMakeshift/InstallBasicPackageFiles.cmake
@@ -90,7 +90,7 @@
 #
 # The ``<Name>ConfigVersion.cmake`` file is generated using
 # :cmake:command:`write_basic_package_version_file`. The ``VERSION``,
-# ``COMPATIBILITY``, and ``ARCH_INDEPENDENT``arguments are passed to this
+# ``COMPATIBILITY``, and ``ARCH_INDEPENDENT`` arguments are passed to this
 # function.
 #
 # ``VERSION`` shall be in the form ``<major>[.<minor>[.<patch>[.<tweak>]]]]``.

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -27,7 +27,7 @@ file(GLOB SPHINX_MANUAL_SOURCES "${conf_docs}/modules/*.rst")
 file(GLOB SPHINX_CMAKE_SOURCES "${PROJECT_SOURCE_DIR}/cmake/CMakeshift/*.cmake")
 add_custom_command(
     OUTPUT ${SPHINX_INDEX_FILE}
-    COMMAND ${SPHINX_EXECUTABLE}
+    COMMAND ${Sphinx_EXECUTABLE}
         -c ${CMAKE_CURRENT_BINARY_DIR}
         -b html ${SPHINX_SOURCE} ${SPHINX_BUILD}
     DEPENDS


### PR DESCRIPTION
According to `FindSphinx.cmake` of this repository, the variable for the
Sphinx executable is called `Sphinx_EXECUTABLE` and not
`SPHINX_EXECUTABLE`.  As CMake variables are case sensitive [1], the
command `make sphinx` did not work and failed.

Furthermore, this commit fixes a Sphinx warning.  A space was missing
after an inline code block which meant that `ARCH_INDEPENDENT` was not
highlighted correctly.

[1] https://cmake.org/cmake/help/latest/manual/cmake-language.7.html#variables